### PR TITLE
Fixing loader going on issue

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1869,7 +1869,7 @@ canvas {
 /* Loading icon for iframe */
 
 iframe {
-	background-image: url('/images/loading.gif');
+	/* background-image: url('/images/loading.gif'); */
 	background-repeat: no-repeat;
 	background-position: 50% 50%;
 }


### PR DESCRIPTION
In Contact Form, in the google form iframe, the loader kept going on and on. Fixing that issue in this commit.